### PR TITLE
アプリ内表示の変更

### DIFF
--- a/app/src/main/java/jp/shono/iso/chatapp/view/activity/ChatRoomActivity.kt
+++ b/app/src/main/java/jp/shono/iso/chatapp/view/activity/ChatRoomActivity.kt
@@ -1,10 +1,12 @@
 package jp.shono.iso.chatapp.view.activity
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -23,6 +25,7 @@ import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.AppGlideModule
 import com.firebase.ui.storage.images.FirebaseImageLoader
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
@@ -169,6 +172,7 @@ class ChatMessageRecyclerViewAdapter(val context: Context) : RecyclerView.Adapte
         return ChatMessageViewHolder(inflate)
     }
 
+    @SuppressLint("ResourceAsColor")
     override fun onBindViewHolder(holder: ChatMessageViewHolder, position: Int) {
         val item = chatMessageList.get(position)
         holder.apply {
@@ -197,6 +201,11 @@ class ChatMessageRecyclerViewAdapter(val context: Context) : RecyclerView.Adapte
                 .addOnFailureListener {
                     userNameView.setText("不明")
                 }
+            if (FirebaseAuth.getInstance().currentUser?.uid.equals(item.uid)) {
+                itemView.setBackgroundColor(Color.CYAN)
+            } else {
+                itemView.setBackgroundColor(Color.WHITE)
+            }
         }
     }
 

--- a/app/src/main/java/jp/shono/iso/chatapp/view/activity/MainActivity.kt
+++ b/app/src/main/java/jp/shono/iso/chatapp/view/activity/MainActivity.kt
@@ -2,6 +2,7 @@ package jp.shono.iso.chatapp.view.activity
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.*
@@ -151,6 +152,11 @@ class ChatRoomListRecyclerViewAdapter(val context: Context) : RecyclerView.Adapt
                 .addOnFailureListener {
                     userNameView.setText("不明")
                 }
+            if (FirebaseAuth.getInstance().currentUser?.uid.equals(item.uid)) {
+                itemView.setBackgroundColor(Color.CYAN)
+            } else {
+                itemView.setBackgroundColor(Color.WHITE)
+            }
             this.itemView.setOnClickListener{
                 listener.onItemClickListener(idList.get(position))
             }

--- a/app/src/main/res/layout/chat_message_cell.xml
+++ b/app/src/main/res/layout/chat_message_cell.xml
@@ -14,12 +14,6 @@
         android:orientation="vertical">
 
         <TextView
-            android:id="@+id/text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textColor="@color/colorPrimaryDark" />
-
-        <TextView
             android:id="@+id/date"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -30,6 +24,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="@color/colorPrimaryDark" />
+
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/colorPrimaryDark"
+            android:textSize="35px"/>
 
         <ImageView
             android:id="@+id/image"


### PR DESCRIPTION
チャットルーム、チャット内のuidが丸見えだったところをユーザ名を出すように変更(ここは本当はmapとか持たせて一度記録したやつはクエリたたかずに持ってこれる形にしたい)
チャットルーム作成日、チャット投稿日の表示を時間まで出すように修正